### PR TITLE
Add three-step hover module HTML

### DIFF
--- a/steps-module.html
+++ b/steps-module.html
@@ -1,231 +1,404 @@
 <!DOCTYPE html>
 <html lang="es">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Módulo de pasos</title>
-  <style>
-    :root {
-      --module-background: #1d75ef;
-      --module-text: #ffffff;
-      --module-accent: #8ce4c2;
-      --module-accent-strong: #5cc69f;
-      --module-step-inactive: rgba(255, 255, 255, 0.24);
-      --module-step-text: #1b4e83;
-      font-size: 16px;
-    }
-
-    * {
-      box-sizing: border-box;
-    }
-
-    body {
-      margin: 0;
-      font-family: "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-      background-color: var(--module-background);
-      color: var(--module-text);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      min-height: 100vh;
-      padding: 2.5rem 1.5rem;
-    }
-
-    .steps-module {
-      background: linear-gradient(140deg, rgba(255, 255, 255, 0.15) 0%, rgba(255, 255, 255, 0.05) 100%);
-      border-radius: 1.5rem;
-      box-shadow: 0 1.5rem 3rem rgba(7, 30, 55, 0.25);
-      padding: 2.5rem;
-      max-width: 540px;
-      width: 100%;
-      backdrop-filter: blur(4px);
-    }
-
-    .steps-eyebrow {
-      font-size: 0.875rem;
-      letter-spacing: 0.18em;
-      text-transform: uppercase;
-      font-weight: 600;
-      color: rgba(255, 255, 255, 0.75);
-      margin-bottom: 1.5rem;
-    }
-
-    .steps-title {
-      font-size: clamp(1.6rem, 3vw + 1rem, 2.75rem);
-      font-weight: 700;
-      margin: 0 0 1.25rem;
-      line-height: 1.2;
-    }
-
-    .steps-title em {
-      color: var(--module-accent);
-      font-style: normal;
-    }
-
-    .steps-description {
-      margin: 0 0 2rem;
-      font-size: 1rem;
-      line-height: 1.55;
-      color: rgba(255, 255, 255, 0.85);
-    }
-
-    .steps-cta {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      gap: 0.5rem;
-      padding: 0.75rem 1.5rem;
-      border-radius: 999px;
-      background: var(--module-accent);
-      color: var(--module-step-text);
-      font-weight: 700;
-      text-decoration: none;
-      transition: background 250ms ease, transform 250ms ease, box-shadow 250ms ease;
-      box-shadow: 0 1rem 2rem rgba(11, 64, 99, 0.2);
-    }
-
-    .steps-cta:hover,
-    .steps-cta:focus-visible {
-      background: var(--module-accent-strong);
-      transform: translateY(-2px);
-      box-shadow: 0 1.5rem 2.25rem rgba(11, 64, 99, 0.35);
-    }
-
-    .steps-cta:focus-visible {
-      outline: 3px solid rgba(255, 255, 255, 0.55);
-      outline-offset: 3px;
-    }
-
-    .steps-list {
-      margin: 2.5rem 0 0;
-      padding: 0;
-      list-style: none;
-      display: flex;
-      gap: clamp(1rem, 3vw, 1.5rem);
-    }
-
-    .steps-item {
-      flex: 1;
-    }
-
-    .step-link {
-      position: relative;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      flex-direction: column;
-      gap: 0.75rem;
-      text-decoration: none;
-      color: var(--module-text);
-      font-weight: 600;
-      letter-spacing: 0.03em;
-      transition: color 250ms ease;
-    }
-
-    .step-number {
-      width: 3.25rem;
-      aspect-ratio: 1;
-      border-radius: 50%;
-      display: grid;
-      place-items: center;
-      background: var(--module-step-inactive);
-      font-size: 1.25rem;
-      font-weight: 700;
-      color: var(--module-text);
-      transition: background 300ms ease, transform 300ms ease, box-shadow 300ms ease;
-    }
-
-    .step-label {
-      opacity: 0;
-      transform: translateY(10px);
-      color: rgba(255, 255, 255, 0.8);
-      font-size: 0.95rem;
-      transition: opacity 300ms ease, transform 300ms ease;
-      text-align: center;
-      max-width: 8rem;
-    }
-
-    .step-link:hover .step-number,
-    .step-link:focus-visible .step-number {
-      background: var(--module-accent);
-      color: var(--module-step-text);
-      transform: scale(1.1);
-      box-shadow: 0 0.75rem 1.5rem rgba(10, 33, 58, 0.35);
-    }
-
-    .step-link:hover .step-label,
-    .step-link:focus-visible .step-label {
-      opacity: 1;
-      transform: translateY(0);
-      color: var(--module-text);
-    }
-
-    .step-link:focus-visible {
-      outline: none;
-    }
-
-    .step-link:focus-visible::after {
-      content: "";
-      position: absolute;
-      inset: -0.35rem;
-      border-radius: 1.5rem;
-      border: 2px solid rgba(255, 255, 255, 0.7);
-    }
-
-    @media (max-width: 520px) {
-      .steps-module {
-        padding: 2rem;
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Widget de tres pasos</title>
+    <style>
+      :root {
+        --widget-background: radial-gradient(circle at 20% 20%, #3a8ef6 0%, #1a2a6c 55%, #020024 100%);
+        --widget-surface: rgba(5, 18, 46, 0.7);
+        --widget-outline: rgba(255, 255, 255, 0.2);
+        --widget-text-strong: #ffffff;
+        --widget-text-soft: rgba(255, 255, 255, 0.75);
+        --widget-accent: #4bf6c1;
+        --widget-accent-strong: #1bd5a0;
+        --widget-step-shadow: rgba(19, 40, 90, 0.55);
+        --widget-button-text: #0b2c4a;
+        font-family: "Poppins", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
       }
 
-      .steps-list {
-        flex-direction: column;
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: clamp(1.5rem, 2vw + 1rem, 3rem);
+        background: var(--widget-background);
+        color: var(--widget-text-strong);
+      }
+
+      .journey-widget {
+        position: relative;
+        overflow: hidden;
+        padding: clamp(2rem, 3vw + 1.5rem, 3.5rem);
+        border-radius: 2rem;
+        border: 1px solid var(--widget-outline);
+        background: linear-gradient(145deg, rgba(9, 26, 60, 0.85) 0%, rgba(9, 26, 60, 0.65) 100%);
+        backdrop-filter: blur(12px);
+        box-shadow: 0 2rem 4rem rgba(3, 9, 22, 0.55);
+        width: min(960px, 100%);
+        isolation: isolate;
+      }
+
+      .journey-widget::before,
+      .journey-widget::after {
+        content: "";
+        position: absolute;
+        border-radius: 999px;
+        filter: blur(65px);
+        opacity: 0.7;
+        z-index: -1;
+      }
+
+      .journey-widget::before {
+        width: 38rem;
+        height: 38rem;
+        background: radial-gradient(circle at 30% 30%, rgba(61, 175, 255, 0.9), rgba(22, 59, 141, 0));
+        top: -18rem;
+        right: -12rem;
+      }
+
+      .journey-widget::after {
+        width: 32rem;
+        height: 32rem;
+        background: radial-gradient(circle at 30% 30%, rgba(75, 246, 193, 0.9), rgba(75, 246, 193, 0));
+        bottom: -16rem;
+        left: -10rem;
+      }
+
+      .widget-header {
+        display: grid;
+        gap: 0.75rem;
+        margin-bottom: clamp(2.25rem, 3vw, 3rem);
+      }
+
+      .widget-eyebrow {
+        text-transform: uppercase;
+        letter-spacing: 0.25em;
+        font-size: 0.85rem;
+        color: rgba(255, 255, 255, 0.6);
+        margin: 0;
+      }
+
+      .widget-title {
+        margin: 0;
+        font-size: clamp(2rem, 5vw, 3.4rem);
+        line-height: 1.15;
+        font-weight: 700;
+      }
+
+      .widget-title em {
+        color: var(--widget-accent);
+        font-style: normal;
+      }
+
+      .widget-description {
+        margin: 0;
+        font-size: 1.05rem;
+        line-height: 1.7;
+        color: var(--widget-text-soft);
+        max-width: 40rem;
+      }
+
+      .widget-cta {
+        justify-self: start;
+        margin-top: 0.75rem;
+        display: inline-flex;
         align-items: center;
+        gap: 0.75rem;
+        padding: 0.85rem 1.75rem;
+        border-radius: 999px;
+        background: linear-gradient(135deg, var(--widget-accent) 0%, var(--widget-accent-strong) 100%);
+        color: var(--widget-button-text);
+        font-weight: 700;
+        text-decoration: none;
+        letter-spacing: 0.02em;
+        box-shadow: 0 1.2rem 2.4rem rgba(14, 54, 67, 0.35);
+        transition: transform 250ms ease, box-shadow 250ms ease;
       }
 
-      .step-link {
-        flex-direction: row;
-        gap: 1.25rem;
+      .widget-cta::after {
+        content: "→";
+        font-size: 1.3rem;
+        transition: transform 250ms ease;
       }
 
-      .step-label {
-        max-width: 100%;
-        text-align: left;
+      .widget-cta:hover,
+      .widget-cta:focus-visible {
+        transform: translateY(-3px);
+        box-shadow: 0 1.6rem 3rem rgba(11, 38, 52, 0.4);
       }
-    }
-  </style>
-</head>
-<body>
-  <section class="steps-module">
-    <p class="steps-eyebrow">Proceso recomendado</p>
-    <h2 class="steps-title">
-      ¿Lorem <em>ipsum dolor</em> sit amet lorem ipsum?
-    </h2>
-    <p class="steps-description">
-      Personaliza este texto para describir brevemente el propósito de tu módulo o la secuencia de pasos que seguirán las personas usuarias.
-    </p>
-    <a class="steps-cta" href="https://tu-enlace-destino.com">
-      ¡Ok!
-    </a>
-    <ol class="steps-list">
-      <li class="steps-item">
-        <a class="step-link" href="https://tu-enlace-paso1.com">
-          <span class="step-number">1</span>
-          <span class="step-label">Descubre la situación inicial</span>
+
+      .widget-cta:hover::after,
+      .widget-cta:focus-visible::after {
+        transform: translateX(6px);
+      }
+
+      .widget-cta:focus-visible {
+        outline: 3px solid rgba(255, 255, 255, 0.7);
+        outline-offset: 4px;
+      }
+
+      .journey-steps {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: grid;
+        gap: 1.5rem;
+      }
+
+      .step-card {
+        position: relative;
+        border-radius: 1.5rem;
+        background: rgba(255, 255, 255, 0.05);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        overflow: hidden;
+        transition: transform 250ms ease, background 250ms ease, border-color 250ms ease;
+      }
+
+      .step-card::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(circle at 15% 15%, rgba(255, 255, 255, 0.22), transparent 55%);
+        opacity: 0;
+        transition: opacity 250ms ease;
+        pointer-events: none;
+      }
+
+      .step-target {
+        position: relative;
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+        gap: clamp(1rem, 2vw, 1.75rem);
+        padding: clamp(1.25rem, 3vw, 1.9rem);
+        text-decoration: none;
+        color: var(--widget-text-strong);
+      }
+
+      .step-target:focus-visible {
+        outline: none;
+      }
+
+      .step-target:focus-visible::after {
+        content: "";
+        position: absolute;
+        inset: 0.35rem;
+        border-radius: 1.15rem;
+        border: 2px solid rgba(255, 255, 255, 0.6);
+      }
+
+      .step-bubble {
+        position: relative;
+        width: clamp(3.75rem, 5vw + 2.5rem, 5rem);
+        aspect-ratio: 1;
+        border-radius: 50%;
+        display: grid;
+        place-items: center;
+        background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.15));
+        box-shadow: 0 1.3rem 2.6rem var(--widget-step-shadow);
+        overflow: hidden;
+      }
+
+      .step-bubble::before {
+        content: "";
+        position: absolute;
+        inset: 12%;
+        border-radius: 50%;
+        background: conic-gradient(from 90deg, rgba(255, 255, 255, 0.85), rgba(75, 246, 193, 0.8), rgba(58, 142, 246, 0.8), rgba(255, 255, 255, 0.85));
+        animation: rotate 8s linear infinite;
+        filter: saturate(1.3);
+      }
+
+      .step-bubble::after {
+        content: "";
+        position: absolute;
+        inset: 22%;
+        border-radius: 50%;
+        background: rgba(3, 14, 34, 0.85);
+      }
+
+      .bubble-index {
+        position: relative;
+        z-index: 1;
+        font-size: 1.5rem;
+        font-weight: 700;
+        letter-spacing: 0.05em;
+      }
+
+      .step-content {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .step-title {
+        margin: 0;
+        font-size: 1.3rem;
+        font-weight: 600;
+      }
+
+      .step-copy {
+        margin: 0;
+        color: var(--widget-text-soft);
+        line-height: 1.6;
+      }
+
+      .step-arrow {
+        font-size: 1.8rem;
+        color: rgba(255, 255, 255, 0.55);
+        transition: transform 250ms ease, color 250ms ease;
+      }
+
+      .step-card:hover,
+      .step-card:has(.step-target:focus-visible) {
+        transform: translateY(-6px);
+        background: rgba(255, 255, 255, 0.09);
+        border-color: rgba(75, 246, 193, 0.4);
+      }
+
+      .step-card:hover::after,
+      .step-card:has(.step-target:focus-visible)::after {
+        opacity: 1;
+      }
+
+      .step-card:hover .step-arrow,
+      .step-card:has(.step-target:focus-visible) .step-arrow {
+        transform: translateX(6px);
+        color: var(--widget-accent);
+      }
+
+      .step-card:hover .step-bubble::after,
+      .step-card:has(.step-target:focus-visible) .step-bubble::after {
+        background: rgba(11, 41, 70, 0.45);
+      }
+
+      .step-card:not(:last-child)::before {
+        content: "";
+        position: absolute;
+        left: clamp(2.9rem, 4vw, 3.75rem);
+        bottom: -1.5rem;
+        width: 2px;
+        height: 3rem;
+        background: linear-gradient(to bottom, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0));
+      }
+
+      @keyframes rotate {
+        from {
+          transform: rotate(0deg);
+        }
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      @media (min-width: 768px) {
+        .journey-steps {
+          grid-template-columns: repeat(3, 1fr);
+        }
+
+        .step-card {
+          min-height: 18rem;
+        }
+
+        .step-card:not(:last-child)::before {
+          top: 50%;
+          left: 100%;
+          bottom: auto;
+          width: clamp(3rem, 6vw, 5rem);
+          height: 2px;
+          transform: translateX(-1.5rem);
+          background: linear-gradient(to right, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0));
+        }
+
+        .step-target {
+          grid-template-columns: 1fr;
+          text-align: center;
+          justify-items: center;
+          gap: 1.25rem;
+        }
+
+        .step-content {
+          gap: 0.5rem;
+        }
+
+        .step-arrow {
+          display: none;
+        }
+      }
+
+      @media (max-width: 520px) {
+        .journey-widget {
+          padding: 2rem;
+        }
+
+        .step-target {
+          grid-template-columns: auto 1fr;
+        }
+
+        .step-arrow {
+          display: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <section class="journey-widget">
+      <header class="widget-header">
+        <p class="widget-eyebrow">Tu plan en 3 pasos</p>
+        <h2 class="widget-title">
+          Transforma tu <em>experiencia digital</em> con un itinerario guiado
+        </h2>
+        <p class="widget-description">
+          Personaliza este texto para explicar rápidamente qué logrará la persona usuaria si sigue los pasos. Puedes resaltar un beneficio clave o invitar a descubrir un programa, curso o servicio.
+        </p>
+        <a class="widget-cta" href="https://tu-enlace-principal.com">
+          Empieza ahora
         </a>
-      </li>
-      <li class="steps-item">
-        <a class="step-link" href="https://tu-enlace-paso2.com">
-          <span class="step-number">2</span>
-          <span class="step-label">Define tus prioridades</span>
-        </a>
-      </li>
-      <li class="steps-item">
-        <a class="step-link" href="https://tu-enlace-paso3.com">
-          <span class="step-number">3</span>
-          <span class="step-label">Activa el plan personalizado</span>
-        </a>
-      </li>
-    </ol>
-  </section>
-</body>
+      </header>
+      <ol class="journey-steps">
+        <li class="step-card">
+          <a class="step-target" href="https://tu-enlace-paso1.com">
+            <span class="step-bubble"><span class="bubble-index">01</span></span>
+            <div class="step-content">
+              <h3 class="step-title">Explora la situación actual</h3>
+              <p class="step-copy">
+                Resume brevemente qué descubrirá la persona en este primer paso. Puedes incluir datos, herramientas o diagnósticos disponibles.
+              </p>
+            </div>
+            <span class="step-arrow">→</span>
+          </a>
+        </li>
+        <li class="step-card">
+          <a class="step-target" href="https://tu-enlace-paso2.com">
+            <span class="step-bubble"><span class="bubble-index">02</span></span>
+            <div class="step-content">
+              <h3 class="step-title">Define tu estrategia ideal</h3>
+              <p class="step-copy">
+                Ajusta este texto para destacar cómo acompañas la toma de decisiones o la planificación. Puedes mencionar plantillas, sesiones o contenido premium.
+              </p>
+            </div>
+            <span class="step-arrow">→</span>
+          </a>
+        </li>
+        <li class="step-card">
+          <a class="step-target" href="https://tu-enlace-paso3.com">
+            <span class="step-bubble"><span class="bubble-index">03</span></span>
+            <div class="step-content">
+              <h3 class="step-title">Activa tu implementación</h3>
+              <p class="step-copy">
+                Describe qué sucede al finalizar: acceso a un acompañamiento, lanzamiento del proyecto o seguimiento de resultados con tu equipo.
+              </p>
+            </div>
+            <span class="step-arrow">→</span>
+          </a>
+        </li>
+      </ol>
+    </section>
+  </body>
 </html>

--- a/steps-module.html
+++ b/steps-module.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Módulo de pasos</title>
+  <style>
+    :root {
+      --module-background: #1d75ef;
+      --module-text: #ffffff;
+      --module-accent: #8ce4c2;
+      --module-accent-strong: #5cc69f;
+      --module-step-inactive: rgba(255, 255, 255, 0.24);
+      --module-step-text: #1b4e83;
+      font-size: 16px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      background-color: var(--module-background);
+      color: var(--module-text);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      padding: 2.5rem 1.5rem;
+    }
+
+    .steps-module {
+      background: linear-gradient(140deg, rgba(255, 255, 255, 0.15) 0%, rgba(255, 255, 255, 0.05) 100%);
+      border-radius: 1.5rem;
+      box-shadow: 0 1.5rem 3rem rgba(7, 30, 55, 0.25);
+      padding: 2.5rem;
+      max-width: 540px;
+      width: 100%;
+      backdrop-filter: blur(4px);
+    }
+
+    .steps-eyebrow {
+      font-size: 0.875rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      font-weight: 600;
+      color: rgba(255, 255, 255, 0.75);
+      margin-bottom: 1.5rem;
+    }
+
+    .steps-title {
+      font-size: clamp(1.6rem, 3vw + 1rem, 2.75rem);
+      font-weight: 700;
+      margin: 0 0 1.25rem;
+      line-height: 1.2;
+    }
+
+    .steps-title em {
+      color: var(--module-accent);
+      font-style: normal;
+    }
+
+    .steps-description {
+      margin: 0 0 2rem;
+      font-size: 1rem;
+      line-height: 1.55;
+      color: rgba(255, 255, 255, 0.85);
+    }
+
+    .steps-cta {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      padding: 0.75rem 1.5rem;
+      border-radius: 999px;
+      background: var(--module-accent);
+      color: var(--module-step-text);
+      font-weight: 700;
+      text-decoration: none;
+      transition: background 250ms ease, transform 250ms ease, box-shadow 250ms ease;
+      box-shadow: 0 1rem 2rem rgba(11, 64, 99, 0.2);
+    }
+
+    .steps-cta:hover,
+    .steps-cta:focus-visible {
+      background: var(--module-accent-strong);
+      transform: translateY(-2px);
+      box-shadow: 0 1.5rem 2.25rem rgba(11, 64, 99, 0.35);
+    }
+
+    .steps-cta:focus-visible {
+      outline: 3px solid rgba(255, 255, 255, 0.55);
+      outline-offset: 3px;
+    }
+
+    .steps-list {
+      margin: 2.5rem 0 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      gap: clamp(1rem, 3vw, 1.5rem);
+    }
+
+    .steps-item {
+      flex: 1;
+    }
+
+    .step-link {
+      position: relative;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-direction: column;
+      gap: 0.75rem;
+      text-decoration: none;
+      color: var(--module-text);
+      font-weight: 600;
+      letter-spacing: 0.03em;
+      transition: color 250ms ease;
+    }
+
+    .step-number {
+      width: 3.25rem;
+      aspect-ratio: 1;
+      border-radius: 50%;
+      display: grid;
+      place-items: center;
+      background: var(--module-step-inactive);
+      font-size: 1.25rem;
+      font-weight: 700;
+      color: var(--module-text);
+      transition: background 300ms ease, transform 300ms ease, box-shadow 300ms ease;
+    }
+
+    .step-label {
+      opacity: 0;
+      transform: translateY(10px);
+      color: rgba(255, 255, 255, 0.8);
+      font-size: 0.95rem;
+      transition: opacity 300ms ease, transform 300ms ease;
+      text-align: center;
+      max-width: 8rem;
+    }
+
+    .step-link:hover .step-number,
+    .step-link:focus-visible .step-number {
+      background: var(--module-accent);
+      color: var(--module-step-text);
+      transform: scale(1.1);
+      box-shadow: 0 0.75rem 1.5rem rgba(10, 33, 58, 0.35);
+    }
+
+    .step-link:hover .step-label,
+    .step-link:focus-visible .step-label {
+      opacity: 1;
+      transform: translateY(0);
+      color: var(--module-text);
+    }
+
+    .step-link:focus-visible {
+      outline: none;
+    }
+
+    .step-link:focus-visible::after {
+      content: "";
+      position: absolute;
+      inset: -0.35rem;
+      border-radius: 1.5rem;
+      border: 2px solid rgba(255, 255, 255, 0.7);
+    }
+
+    @media (max-width: 520px) {
+      .steps-module {
+        padding: 2rem;
+      }
+
+      .steps-list {
+        flex-direction: column;
+        align-items: center;
+      }
+
+      .step-link {
+        flex-direction: row;
+        gap: 1.25rem;
+      }
+
+      .step-label {
+        max-width: 100%;
+        text-align: left;
+      }
+    }
+  </style>
+</head>
+<body>
+  <section class="steps-module">
+    <p class="steps-eyebrow">Proceso recomendado</p>
+    <h2 class="steps-title">
+      ¿Lorem <em>ipsum dolor</em> sit amet lorem ipsum?
+    </h2>
+    <p class="steps-description">
+      Personaliza este texto para describir brevemente el propósito de tu módulo o la secuencia de pasos que seguirán las personas usuarias.
+    </p>
+    <a class="steps-cta" href="https://tu-enlace-destino.com">
+      ¡Ok!
+    </a>
+    <ol class="steps-list">
+      <li class="steps-item">
+        <a class="step-link" href="https://tu-enlace-paso1.com">
+          <span class="step-number">1</span>
+          <span class="step-label">Descubre la situación inicial</span>
+        </a>
+      </li>
+      <li class="steps-item">
+        <a class="step-link" href="https://tu-enlace-paso2.com">
+          <span class="step-number">2</span>
+          <span class="step-label">Define tus prioridades</span>
+        </a>
+      </li>
+      <li class="steps-item">
+        <a class="step-link" href="https://tu-enlace-paso3.com">
+          <span class="step-number">3</span>
+          <span class="step-label">Activa el plan personalizado</span>
+        </a>
+      </li>
+    </ol>
+  </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone three-step module HTML snippet with hover animations
- include customizable headings, copy, and links along with responsive styles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdb565329883329050c8d098b0e225